### PR TITLE
Adds openWorkspaceRoot,  openWorkspaceRootIntegrated

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
       {
         "command": "openInTerminal.openIntegrated",
         "title": "Open in Integrated Terminal"
+      },
+      {
+        "command": "openInTerminal.openWorkspaceRoot",
+        "title": "Open Workspace Root in Terminal"
+      },
+      {
+        "command": "openInTerminal.openWorkspaceRootIntegrated",
+        "title": "Open Workspace Root in Integrated Terminal"
       }
     ]
   },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -10,11 +10,23 @@ import Utils from './utils';
 
 /* COMMANDS */
 
-async function open ( integrated = false ) {
+async function open ( integrated = false, workspaceRootFolder = false ) {
 
   const {activeTextEditor} = vscode.window,
-        editorPath = activeTextEditor ? activeTextEditor.document.fileName : undefined,
-        folderPath = editorPath && absolute ( editorPath ) ? path.dirname ( editorPath ) : vscode.workspace.rootPath;
+        editorPath = activeTextEditor ? activeTextEditor.document.fileName : undefined;
+
+  let folderPath;
+  if ( editorPath ) {
+    if ( workspaceRootFolder ) {
+      // VSCode vscode.d.ts does not define prop workspaceFolders yet
+      // const workspaceFolder = vscode.workspace.workspaceFolders.find(f => editorPath.match(`${path.sep}${f.name}${path.sep}?`));
+      const workspaceFolder = (vscode.workspace as any).workspaceFolders.find(f => editorPath.match(`${path.sep}${f.name}${path.sep}?`));
+      folderPath = workspaceFolder && workspaceFolder.uri.path;
+    }
+
+    // fallback to file base editorPath
+    folderPath = folderPath || (absolute(editorPath) ? path.dirname(editorPath) : vscode.workspace.rootPath);
+  }
 
   if ( !folderPath ) return vscode.window.showErrorMessage ( 'You have to open a project or a file before opening it in Terminal' );
 
@@ -45,6 +57,18 @@ function openIntegrated () {
 
 }
 
+function openWorkspaceRoot () {
+
+  return open ( false, true );
+
+}
+
+function openWorkspaceRootIntegrated () {
+
+  return open ( true, true );
+
+}
+
 /* EXPORT */
 
-export {open, openIntegrated};
+export {open, openIntegrated, openWorkspaceRoot, openWorkspaceRootIntegrated};

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,13 +18,14 @@ async function open ( integrated = false, workspaceRootFolder = false ) {
   let folderPath;
   if ( editorPath ) {
     if ( workspaceRootFolder ) {
-      // VSCode vscode.d.ts does not define prop workspaceFolders yet
+      // VSCode vscode.d.ts does define prop workspaceFolders nut complains with
+      // error: [ts] Property 'workspaceFolders' does not exist on type 'typeof workspace'.
       // const workspaceFolder = vscode.workspace.workspaceFolders.find(f => editorPath.match(`${path.sep}${f.name}${path.sep}?`));
       const workspaceFolder = (vscode.workspace as any).workspaceFolders.find(f => editorPath.match(`${path.sep}${f.name}${path.sep}?`));
       folderPath = workspaceFolder && workspaceFolder.uri.path;
     }
 
-    // fallback to file base editorPath
+    // fallback to file's base editorPath
     folderPath = folderPath || (absolute(editorPath) ? path.dirname(editorPath) : vscode.workspace.rootPath);
   }
 


### PR DESCRIPTION
This PR adds the above two commands.  They are identical to the existing commands except they attempt to open the terminal in the folder at the root of the current file's workspace.

This is not a critical feature but I'm tired of doing `cd ..`'s when I open the terminal to get to the projects/workspace root.